### PR TITLE
Fix misspelling of "suppress" as "supress"

### DIFF
--- a/Docs/Add-ExcelWorkSheet.md
+++ b/Docs/Add-ExcelWorkSheet.md
@@ -14,7 +14,7 @@ schema: 2.0.0
 
 ```
 Add-ExcelWorkSheet [[-ExcelDocument] <ExcelPackage>] [[-WorksheetName] <String>] [[-Option] <String>]
- [[-Supress] <Boolean>] [<CommonParameters>]
+ [[-Suppress] <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,8 +62,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Supress
-{{Fill Supress Description}}
+### -Suppress
+{{Fill Suppress Description}}
 
 ```yaml
 Type: Boolean

--- a/Docs/Add-ExcelWorkSheetCell.md
+++ b/Docs/Add-ExcelWorkSheetCell.md
@@ -14,7 +14,7 @@ schema: 2.0.0
 
 ```
 Add-ExcelWorkSheetCell [[-ExcelWorksheet] <ExcelWorksheet>] [[-CellRow] <Int32>] [[-CellColumn] <Int32>]
- [[-CellValue] <Object>] [[-Supress] <Boolean>] [<CommonParameters>]
+ [[-CellValue] <Object>] [[-Suppress] <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,8 +91,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Supress
-{{Fill Supress Description}}
+### -Suppress
+{{Fill Suppress Description}}
 
 ```yaml
 Type: Boolean

--- a/Docs/Add-ExcelWorksheetData.md
+++ b/Docs/Add-ExcelWorksheetData.md
@@ -17,7 +17,7 @@ Add-ExcelWorksheetData [[-ExcelDocument] <ExcelPackage>] [[-ExcelWorksheet] <Obj
  [[-Option] <String>] [[-StartRow] <Int32>] [[-StartColumn] <Int32>] [-AutoFit] [-AutoFilter] [-FreezeTopRow]
  [-FreezeFirstColumn] [-FreezeTopRowFirstColumn] [[-FreezePane] <Int32[]>] [[-ExcelWorksheetName] <String>]
  [-Transpose] [[-TransposeSort] <String>] [-PreScanHeaders] [[-TableStyle] <TableStyles>]
- [[-TableName] <String>] [[-Supress] <Boolean>] [<CommonParameters>]
+ [[-TableName] <String>] [[-Suppress] <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -245,8 +245,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Supress
-{{Fill Supress Description}}
+### -Suppress
+{{Fill Suppress Description}}
 
 ```yaml
 Type: Boolean

--- a/Docs/Find-ExcelDocumentText.md
+++ b/Docs/Find-ExcelDocumentText.md
@@ -14,7 +14,7 @@ schema: 2.0.0
 
 ```
 Find-ExcelDocumentText [[-FilePath] <String>] [[-FilePathTarget] <String>] [[-Find] <String>] [-Replace]
- [[-ReplaceWith] <String>] [-Regex] [-OpenWorkBook] [[-Supress] <Boolean>] [<CommonParameters>]
+ [[-ReplaceWith] <String>] [-Regex] [-OpenWorkBook] [[-Suppress] <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -136,8 +136,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Supress
-{{Fill Supress Description}}
+### -Suppress
+{{Fill Suppress Description}}
 
 ```yaml
 Type: Boolean

--- a/Docs/Get-ExcelWorkSheetCell.md
+++ b/Docs/Get-ExcelWorkSheetCell.md
@@ -14,7 +14,7 @@ schema: 2.0.0
 
 ```
 Get-ExcelWorkSheetCell [[-ExcelWorksheet] <ExcelWorksheet>] [[-CellRow] <Int32>] [[-CellColumn] <Int32>]
- [[-Supress] <Boolean>] [<CommonParameters>]
+ [[-Suppress] <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -76,8 +76,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Supress
-{{Fill Supress Description}}
+### -Suppress
+{{Fill Suppress Description}}
 
 ```yaml
 Type: Boolean

--- a/Docs/Set-ExcelProperties.md
+++ b/Docs/Set-ExcelProperties.md
@@ -34,7 +34,7 @@ $FilePath = "$Env:USERPROFILE\Desktop\PSWriteExcel-Example-SetProperties.xlsx"
 
 $Excel = New-ExcelDocument -Verbose
 
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
 
 $myitems0 = @(
     [pscustomobject]@{name = "Joe"; age = 32; info = "Cat lover"},
@@ -42,7 +42,7 @@ $myitems0 = @(
     [pscustomobject]@{name = "Jason another one"; age = 42; info = "Food lover"
     }
 )
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
 
 Set-ExcelProperties -ExcelDocument $Excel -Author 'Przemyslaw Klys' -Title 'This is a test'
 Set-ExcelProperties -ExcelDocument $Excel -Comments 'Testing PSWriteExcel' -Subject 'Subject'

--- a/Examples/Example.01.AddFormula.ps1
+++ b/Examples/Example.01.AddFormula.ps1
@@ -3,7 +3,7 @@
 $FilePath = "$Env:USERPROFILE\Desktop\PSWriteExcel-Example-Test.xlsx"
 
 $Excel = New-ExcelDocument -Verbose
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Suppress $False -Option 'Replace'
 
 Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 5 -CellValue 5
 Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 2 -CellColumn 5 -CellValue 5

--- a/Examples/Example.02.AddFormulaRecalulate.ps1
+++ b/Examples/Example.02.AddFormulaRecalulate.ps1
@@ -3,7 +3,7 @@
 $FilePath = "$PSScriptRoot\Output\PSWriteExcel.FormulaTest.xlsx"
 
 $Excel = New-ExcelDocument -Verbose
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Suppress $False -Option 'Replace'
 
 Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 5 -CellValue 5
 Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 2 -CellColumn 5 -CellValue 5

--- a/Examples/Example.04.AddFormula.ps1
+++ b/Examples/Example.04.AddFormula.ps1
@@ -3,7 +3,7 @@
 $FilePath = "$PSScriptRoot\Output\PSWriteExcel.FormulaTest7.xlsx"
 
 $Excel = New-ExcelDocument -Verbose
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Suppress $False -Option 'Replace'
 
 #Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 5 -CellValue 5
 #Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 2 -CellColumn 5 -CellValue 5

--- a/Examples/Example.05.TestingMaximumCellLength.ps1
+++ b/Examples/Example.05.TestingMaximumCellLength.ps1
@@ -2,7 +2,7 @@ Import-Module $PSScriptRoot\..\PSWriteExcel.psd1 -Force
 
 $FilePath = "$PSScriptRoot\Output\PSWriteExcel-Example-TestingMaximumCellLength.xlsx"
 $Excel = New-ExcelDocument -Verbose
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
 $Value = ([string]3276999).PadRight(32767999, '0')
 Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 1 -CellValue $Value
 Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePath -OpenWorkBook

--- a/Examples/Run-Example-CreateExcel.ps1
+++ b/Examples/Run-Example-CreateExcel.ps1
@@ -5,12 +5,12 @@ $FilePath = "$Env:USERPROFILE\Desktop\PSWriteExcel-Example-Test.xlsx"
 
 $Excel = New-ExcelDocument -Verbose
 
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Supress $False -Option 'Replace'
-$ExcelWorkSheet2 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Supress $False -Option 'Replace'
-$ExcelWorkSheet3 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'This is very long title - Will be cut off at some point' -Supress $false -Option 'Replace'
-Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Supress $True
-Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Option 'Skip' -Supress $True
-Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Supress $True
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Suppress $False -Option 'Replace'
+$ExcelWorkSheet2 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Suppress $False -Option 'Replace'
+$ExcelWorkSheet3 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'This is very long title - Will be cut off at some point' -Suppress $false -Option 'Replace'
+Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Suppress $True
+Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Option 'Skip' -Suppress $True
+Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Suppress $True
 #Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 1 -CellValue 'Test'
 
 $myitems0 = @(
@@ -20,12 +20,12 @@ $myitems0 = @(
     }
 )
 
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet2 -DataTable $myitems0 -AutoFit -AutoFilter  -Supress $True -PreScanHeaders -TabColor ChartreuseYellow
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet3 -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True -TabColor DarkPurple
-Add-ExcelWorksheetData -DataTable $myitems0 -Verbose -AutoFit -AutoFilter -Supress $True -TabColor Bisque -ExcelDocument $Excel
-Add-ExcelWorksheetData -DataTable $myitems0 -AutoFit -AutoFilter -ExcelDocument $Excel -Supress $True -TabColor Grey
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet2 -DataTable $myitems0 -AutoFit -AutoFilter  -Suppress $True -PreScanHeaders -TabColor ChartreuseYellow
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet3 -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True -TabColor DarkPurple
+Add-ExcelWorksheetData -DataTable $myitems0 -Verbose -AutoFit -AutoFilter -Suppress $True -TabColor Bisque -ExcelDocument $Excel
+Add-ExcelWorksheetData -DataTable $myitems0 -AutoFit -AutoFilter -ExcelDocument $Excel -Suppress $True -TabColor Grey
 
-$myitems0 | Add-ExcelWorksheetData -AutoFit -AutoFilter -ExcelDocument $Excel -ExcelWorksheetName 'Hello Motto' -Supress $True -FreezeTopRow -FreezeFirstColumn -Verbose
+$myitems0 | Add-ExcelWorksheetData -AutoFit -AutoFilter -ExcelDocument $Excel -ExcelWorksheetName 'Hello Motto' -Suppress $True -FreezeTopRow -FreezeFirstColumn -Verbose
 
 Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePath -OpenWorkBook

--- a/Examples/Run-Example-FindReplace.ps1
+++ b/Examples/Run-Example-FindReplace.ps1
@@ -19,4 +19,4 @@ $Cells1 = Find-ExcelDocumentText -FilePath $FilePath -Find 'evotec' -Replace -Re
 $Cells2 = Find-ExcelDocumentText -FilePath $FilePath -Find 'evotec' -Replace -ReplaceWith 'somethingelse' -FilePathTarget $FilePathOutput2 -OpenWorkBook:$false -Regex
 
 # Do not display found cells, replace evotec with somethingelse but don't check for case sensitivity. It will replace evotec, Evotec. Finally save it to file and open workbook.
-Find-ExcelDocumentText -FilePath $FilePath -Find 'evotec' -Replace -ReplaceWith 'somethingelse' -FilePathTarget $FilePathOutput2 -OpenWorkBook -Regex -Supress $true
+Find-ExcelDocumentText -FilePath $FilePath -Find 'evotec' -Replace -ReplaceWith 'somethingelse' -FilePathTarget $FilePathOutput2 -OpenWorkBook -Regex -Suppress $true

--- a/Examples/Run-SetExcelWorkSheetCell.ps1
+++ b/Examples/Run-SetExcelWorkSheetCell.ps1
@@ -4,7 +4,7 @@ $FilePath = "$Env:USERPROFILE\Desktop\PSWriteExcel-Example-SetExcelWorkSheetCell
 
 $Excel = New-ExcelDocument -Verbose
 
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
 
 $myitems0 = @(
     [pscustomobject]@{name = "Joe"; age = 32; info = "Cat lover"},
@@ -12,7 +12,7 @@ $myitems0 = @(
     [pscustomobject]@{name = "Jason another one"; age = 42; info = "Food lover"
     }
 )
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
 
 Set-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 2 -FontName 'Arial' -FontSize 15 -FontBold $true
 

--- a/Examples/Run-SetProperties.ps1
+++ b/Examples/Run-SetProperties.ps1
@@ -4,7 +4,7 @@ $FilePath = "$Env:USERPROFILE\Desktop\PSWriteExcel-Example-SetProperties.xlsx"
 
 $Excel = New-ExcelDocument -Verbose
 
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
 
 $myitems0 = @(
     [pscustomobject]@{name = "Joe"; age = 32; info = "Cat lover"},
@@ -12,7 +12,7 @@ $myitems0 = @(
     [pscustomobject]@{name = "Jason another one"; age = 42; info = "Food lover"
     }
 )
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
 
 Set-ExcelProperties -ExcelDocument $Excel -Author 'Przemyslaw Klys' -Title 'This is a test'
 Set-ExcelProperties -ExcelDocument $Excel -Comments 'Testing PSWriteExcel' -Subject 'Subject'

--- a/Examples/SpeedTests/Run-Example-Speed.ps1
+++ b/Examples/SpeedTests/Run-Example-Speed.ps1
@@ -22,39 +22,39 @@ $MyItems3 = @(
 )
 
 $Excel = New-ExcelDocument -Verbose
-#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems0 -Verbose -AutoFit -AutoFilter -Supress $True
-#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems1 -Verbose -AutoFit -AutoFilter -Supress $True
-#$myitems0 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Supress $True
-#$myitems1 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Supress $True
-#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems2 -Verbose -AutoFit -AutoFilter -Supress $True
-$myitems2 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Supress $True
-$myitems3 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Supress $True
-'testz','tests2' | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Supress $True
-#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable 'testz','tests2' -Verbose -AutoFit -AutoFilter -Supress $True
-#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems2 -Verbose -AutoFit -AutoFilter -Supress $True
-#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems3 -Verbose -AutoFit -AutoFilter -Supress $True
+#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems0 -Verbose -AutoFit -AutoFilter -Suppress $True
+#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems1 -Verbose -AutoFit -AutoFilter -Suppress $True
+#$myitems0 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Suppress $True
+#$myitems1 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Suppress $True
+#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems2 -Verbose -AutoFit -AutoFilter -Suppress $True
+$myitems2 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Suppress $True
+$myitems3 | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Suppress $True
+'testz','tests2' | Add-ExcelWorksheetData -ExcelDocument $Excel -Verbose -AutoFit -AutoFilter -Suppress $True
+#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable 'testz','tests2' -Verbose -AutoFit -AutoFilter -Suppress $True
+#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems2 -Verbose -AutoFit -AutoFilter -Suppress $True
+#Add-ExcelWorksheetData -ExcelDocument $Excel -DataTable $myitems3 -Verbose -AutoFit -AutoFilter -Suppress $True
 Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePath -OpenWorkBook
 <#
-$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Supress $False -Option 'Replace'
-$ExcelWorkSheet2 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Supress $False -Option 'Replace'
-$ExcelWorkSheet3 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'This is very long title - Will be cut off at some point' -Supress $false -Option 'Replace'
-Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Supress $True
-Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Option 'Skip' -Supress $True
-Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Supress $True
+$ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 10' -Suppress $False -Option 'Replace'
+$ExcelWorkSheet2 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Suppress $False -Option 'Replace'
+$ExcelWorkSheet3 = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'This is very long title - Will be cut off at some point' -Suppress $false -Option 'Replace'
+Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Suppress $True
+Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 2' -Option 'Skip' -Suppress $True
+Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Option 'Replace' -Suppress $True
 #Add-ExcelWorkSheetCell -ExcelWorksheet $ExcelWorkSheet -CellRow 1 -CellColumn 1 -CellValue 'Test'
 
 
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet2 -DataTable $myitems0 -AutoFit -AutoFilter  -Supress $True
-Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet3 -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet2 -DataTable $myitems0 -AutoFit -AutoFilter  -Suppress $True
+Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet3 -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
 
 #>
 
 
 
-#Add-ExcelWorksheetData -DataTable $myitems0 -AutoFit -AutoFilter -ExcelDocument $Excel -Supress $True
+#Add-ExcelWorksheetData -DataTable $myitems0 -AutoFit -AutoFilter -ExcelDocument $Excel -Suppress $True
 
-#$myitems0 | Add-ExcelWorksheetData -AutoFit -AutoFilter -ExcelDocument $Excel -ExcelWorksheetName 'Hello Motto' -Supress $True -FreezeTopRow -FreezeFirstColumn -Verbose
+#$myitems0 | Add-ExcelWorksheetData -AutoFit -AutoFilter -ExcelDocument $Excel -ExcelWorksheetName 'Hello Motto' -Suppress $True -FreezeTopRow -FreezeFirstColumn -Verbose
 
 
 

--- a/Examples/SpeedTests/Run-Example-Speed1.ps1
+++ b/Examples/SpeedTests/Run-Example-Speed1.ps1
@@ -13,6 +13,6 @@ Measure-Collection -Name 'ConvertTo-Excel' -ScriptBlock {
 $FilePath = "$PSScriptRoot\PSWriteExcel-Example-Test.xlsx"
 Measure-Collection -Name 'Add-ExcelWorkSheet' -ScriptBlock {
     $Excel = New-ExcelDocument -Verbose
-    Add-ExcelWorksheetData -ExcelDocument $Excel -Supress $True -DataTable $Process -ExcelWorksheetName 'Test' -Verbose
+    Add-ExcelWorksheetData -ExcelDocument $Excel -Suppress $True -DataTable $Process -ExcelWorksheetName 'Test' -Verbose
     Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePath #-OpenWorkBook
 }

--- a/Public/Add-ExcelWorkSheet.ps1
+++ b/Public/Add-ExcelWorkSheet.ps1
@@ -4,7 +4,7 @@ function Add-ExcelWorkSheet {
         [OfficeOpenXml.ExcelPackage]  $ExcelDocument,
         [alias('Name')][string] $WorksheetName,
         [ValidateSet("Replace", "Skip", "Rename")][string] $Option = 'Skip',
-        [bool] $Supress
+        [alias('Supress')][bool] $Suppress
     )
     $WorksheetName = $WorksheetName.Trim()
     if ($WorksheetName.Length -eq 0) {
@@ -25,11 +25,11 @@ function Add-ExcelWorkSheet {
         } elseif ($Option -eq 'Replace') {
             Write-Verbose "Add-ExcelWorkSheet - WorksheetName: '$WorksheetName' - exists. Replacing worksheet with empty worksheet."
             Remove-ExcelWorksheet -ExcelDocument $ExcelDocument -ExcelWorksheet $PreviousWorksheet
-            $Data = Add-ExcelWorkSheet -ExcelDocument $ExcelDocument -WorksheetName $WorksheetName -Option $Option -Supress $False
+            $Data = Add-ExcelWorkSheet -ExcelDocument $ExcelDocument -WorksheetName $WorksheetName -Option $Option -Suppress $False
         } elseif ($Option -eq 'Rename') {
             Write-Verbose "Add-ExcelWorkSheet - Worksheet: '$WorksheetName' already exists. Renaming worksheet to random value."
             $WorksheetName = Get-RandomStringName -Size 31
-            $Data = Add-ExcelWorkSheet -ExcelDocument $ExcelDocument -WorksheetName $WorksheetName -Option $Option -Supress $False
+            $Data = Add-ExcelWorkSheet -ExcelDocument $ExcelDocument -WorksheetName $WorksheetName -Option $Option -Suppress $False
             Write-Verbose "Add-ExcelWorkSheet - New worksheet name $WorksheetName"
         } else {
             #Write-Verbose "Future use..."
@@ -46,5 +46,5 @@ function Add-ExcelWorkSheet {
         #Write-Warning "Add-ExcelWorkSheet - Maximum amount of chars is 31 for worksheet name"
         #}
     }
-    if ($Supress) { return } else { return $data }
+    if ($Suppress) { return } else { return $data }
 }

--- a/Public/Add-ExcelWorkSheetData.ps1
+++ b/Public/Add-ExcelWorkSheetData.ps1
@@ -20,7 +20,7 @@ function Add-ExcelWorksheetData {
         [alias('TableStyles')][nullable[OfficeOpenXml.Table.TableStyles]] $TableStyle,
         [string] $TableName,
         [string] $TabColor,
-        [bool] $Supress
+        [alias('Supress')][bool] $Suppress
     )
     Begin {
         $FirstRun = $True
@@ -183,7 +183,7 @@ function Add-ExcelWorksheetData {
                 $ExcelWorksheet.TabColor = ConvertFrom-Color -Color $TabColor -AsDrawingColor
             }
             #Write-Verbose 'Add-ExcelWorksheetData - Ending...'
-            if ($Supress) { return } else { return $ExcelWorkSheet }
+            if ($Suppress) { return } else { return $ExcelWorkSheet }
         }
     }
 

--- a/Public/ConvertTo-Excel.ps1
+++ b/Public/ConvertTo-Excel.ps1
@@ -59,7 +59,7 @@ function ConvertTo-Excel {
             -TransposeSort $TransposeSort `
             -Option $Option `
             -TableStyle $TableStyle `
-            -TableName $TableName -AllProperties:$AllProperties.IsPresent -Supress $true
+            -TableName $TableName -AllProperties:$AllProperties.IsPresent -Suppress $true
         Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePath -OpenWorkBook:$OpenWorkBook
     }
 }

--- a/Public/Find-ExcelDocumentText.ps1
+++ b/Public/Find-ExcelDocumentText.ps1
@@ -8,7 +8,7 @@ function Find-ExcelDocumentText {
         [string] $ReplaceWith,
         [switch] $Regex,
         [switch] $OpenWorkBook,
-        [bool] $Supress
+        [alias('Supress')][bool] $Suppress
     )
     $Excel = Get-ExcelDocument -Path $FilePath
     if ($Excel) {
@@ -43,7 +43,7 @@ function Find-ExcelDocumentText {
         if ($Replace) {
             Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePathTarget -OpenWorkBook:$OpenWorkBook
         }
-        if ($Supress) {
+        if ($Suppress) {
             return
         } else {
             return $Addresses

--- a/Public/Get-ExcelWorkSheetCell.ps1
+++ b/Public/Get-ExcelWorkSheetCell.ps1
@@ -4,7 +4,7 @@ function Get-ExcelWorkSheetCell {
         [OfficeOpenXml.ExcelWorksheet] $ExcelWorksheet,
         [int] $CellRow,
         [int] $CellColumn,
-        [bool] $Supress
+        [alias('Supress')][bool] $Suppress
     )
     if ($ExcelWorksheet) {
         $ExcelWorksheet.Cells[$CellRow, $CellColumn].Value

--- a/Public/Worksheet.ps1
+++ b/Public/Worksheet.ps1
@@ -15,14 +15,14 @@
             [string] $Name,
             [ValidateSet("Replace", "Skip", "Rename")][string] $Option = 'Replace',
             [string] $TabColor,
-            [bool] $Supress,
+            [alias('Supress')][bool] $Suppress,
             [switch] $AutoFilter,
             [switch] $AutoFit
         )
         $addExcelWorkSheetDataSplat = @{
             DataTable          = $DataTable
             TabColor           = $TabColor
-            Supress            = $Supress
+            Suppress            = $Suppress
             Option             = $Option
             ExcelDocument      = $ExcelDocument
             ExcelWorksheetName = $Name
@@ -34,7 +34,7 @@
     $ExcelWorkSheetParameters = [ordered] @{
         DataTable     = $DataTable
         TabColor      = $TabColor
-        Supress       = $true
+        Suppress       = $true
         Option        = $Option
         ExcelDocument = $Script:Excel.ExcelDocument
         Name          = $Name

--- a/Tests/Get-ExcelProperties.Tests.ps1
+++ b/Tests/Get-ExcelProperties.Tests.ps1
@@ -18,8 +18,8 @@ $PSDefaultParameterValues = @{
 Describe 'Get-ExcelProperties - Getting Excel Properties' {
     It 'Using Get-ExcelProperties - Getting Author, Title and Subject Properties should be readable' {
         $Excel = New-ExcelDocument
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Author 'Przemyslaw Klys' -Title 'PSWriteExcel Set-Properties' -Subject 'PSWriteExcel'
 
         $Properties = Get-ExcelProperties -ExcelDocument $Excel
@@ -32,8 +32,8 @@ Describe 'Get-ExcelProperties - Getting Excel Properties' {
         [DateTime] $Modified = Get-Date -Year '2018' -Month '09' -Day '27' -Hour 0 -Minute 0 -Second 0 -Millisecond 0
 
         $Excel = New-ExcelDocument
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Created $Created -Modified $Modified -Category 'Excel'
 
         $Properties = Get-ExcelProperties -ExcelDocument $Excel
@@ -46,8 +46,8 @@ Describe 'Get-ExcelProperties - Getting Excel Properties' {
         [DateTime] $Modified = Get-Date -Year '2018' -Month '09' -Day '27' -Hour 0 -Minute 0 -Second 0 -Millisecond 0
 
         $Excel = New-ExcelDocument
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Application 'Test 1' -AppVersion 'Test 2' -Keywords 'My key word' -LastModifiedBy 'Przemyslaw Klys' -LastPrinted 'Evotec' -LinksUpToDate $false -Manager 'Przemyslaw Klys' -ScaleCrop $true -SharedDoc $false -Status 'My status'
 
         $Properties = Get-ExcelProperties -ExcelDocument $Excel
@@ -69,8 +69,8 @@ Describe 'Get-ExcelProperties - Getting Excel Properties' {
         $FilePath = [IO.Path]::Combine($TemporaryFolder, "Get-ExpelProperties-Test.xlsx")
 
         $Excel = New-ExcelDocument
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Application 'Test 1' -AppVersion 'Test 2' -Keywords 'My key word' -LastModifiedBy 'Przemyslaw Klys' -LastPrinted 'Evotec' -LinksUpToDate $false -Manager 'Przemyslaw Klys' -ScaleCrop $true -SharedDoc $false -Status 'My status'
         Save-ExcelDocument -ExcelDocument $Excel -FilePath $FilePath
 

--- a/Tests/Get-ExcelProperties.Tests.ps1
+++ b/Tests/Get-ExcelProperties.Tests.ps1
@@ -89,4 +89,15 @@ Describe 'Get-ExcelProperties - Getting Excel Properties' {
 
         Remove-Item -Path $FilePath -Confirm:$false -ErrorAction SilentlyContinue
     }
+    It 'Using Get-ExcelProperties - Previous "Supress" parameter should still work on Add-ExcelWorkSheet and Add-ExcelWorkSheetData' {
+        $Excel = New-ExcelDocument
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        Set-ExcelProperties -ExcelDocument $Excel -Author 'Przemyslaw Klys' -Title 'PSWriteExcel Set-Properties' -Subject 'PSWriteExcel'
+
+        $Properties = Get-ExcelProperties -ExcelDocument $Excel
+        $Properties.Author | Should -Be 'Przemyslaw Klys'
+        $Properties.Title | Should -Be 'PSWriteExcel Set-Properties'
+        $Properties.Subject | Should -Be 'PSWriteExcel'
+    }    
 }

--- a/Tests/Set-ExcelProperties.Tests.ps1
+++ b/Tests/Set-ExcelProperties.Tests.ps1
@@ -24,8 +24,8 @@ $PSDefaultParameterValues = @{
 Describe 'Set-ExcelProperties - Setting Excel Properties' {
     It 'Using Set-ExcelProperties - Setting Author, Title and Subject Properties should work' {
         $Excel = New-ExcelDocument -Verbose
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Author 'Przemyslaw Klys' -Title 'PSWriteExcel Set-Properties' -Subject 'PSWriteExcel'
 
         $Excel.Workbook.Properties.Author | Should -Be 'Przemyslaw Klys'
@@ -37,8 +37,8 @@ Describe 'Set-ExcelProperties - Setting Excel Properties' {
         [DateTime] $Modified = Get-Date -Year '2018' -Month '09' -Day '27' -Hour 0 -Minute 0 -Second 0 -Millisecond 0
 
         $Excel = New-ExcelDocument -Verbose
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Created $Created -Modified $Modified -Category 'Excel'
 
         $Excel.Workbook.Properties.Created | Should -Be $Created
@@ -50,8 +50,8 @@ Describe 'Set-ExcelProperties - Setting Excel Properties' {
         [DateTime] $Modified = Get-Date -Year '2018' -Month '09' -Day '27' -Hour 0 -Minute 0 -Second 0 -Millisecond 0
 
         $Excel = New-ExcelDocument -Verbose
-        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Supress $False -Option 'Replace'
-        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Supress $True
+        $ExcelWorkSheet = Add-ExcelWorkSheet -ExcelDocument $Excel -WorksheetName 'Test 1' -Suppress $False -Option 'Replace'
+        Add-ExcelWorksheetData -ExcelWorksheet $ExcelWorkSheet -DataTable $myitems0 -AutoFit -AutoFilter -Suppress $True
         Set-ExcelProperties -ExcelDocument $Excel -Application 'Test 1' -AppVersion 'Test 2' -Keywords 'My key word' -LastModifiedBy 'Przemyslaw Klys' -LastPrinted 'Evotec' -LinksUpToDate $false -Manager 'Przemyslaw Klys' -ScaleCrop $true -SharedDoc $false -Status 'My status'
 
         $Excel.Workbook.Properties.Application | Should -Be 'Test 1'


### PR DESCRIPTION
Per issue #6 , this fixes the misspelling of "suppress" as "supress" across the module, while adding aliases to each function for the previous "supress" spelling to ensure backwards compatibility. I added a Pester test for the alias as well.